### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -1,5 +1,8 @@
 name: Next CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master, main]


### PR DESCRIPTION
Potential fix for [https://github.com/Adam-Robson/catalogue/security/code-scanning/1](https://github.com/Adam-Robson/catalogue/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the least privileges required for the workflow. Based on the provided steps, the workflow primarily involves checking out the repository and running build commands, which only require `contents: read` permissions. No write permissions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
